### PR TITLE
tests: Print the output of failed node_tunnel_runners

### DIFF
--- a/binary/Dockerfile.linux-binary
+++ b/binary/Dockerfile.linux-binary
@@ -20,8 +20,14 @@ RUN apt-get update --fix-missing && apt-get install -y \
   python-pip \
   python-virtualenv \
   sudo \
+  zip \
   && pip install pip --upgrade \
   && pip install pyinstaller pytest \
-  && make binary
+  && make binary \
+  && mkdir -p tmp/bin \
+  && cp -p dist/dcos-tunnel tmp/bin \
+  && cd tmp \
+  && zip -r dcos-tunnel.zip bin/ \
+  && mv dcos-tunnel.zip ..
 
 ENTRYPOINT ["/dcos-tunnel/bin/entrypoint.sh"]

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -77,7 +77,14 @@ def _node_tunnel_runner(ttype, tunnel_args, args, delay=5, sudo=False):
     if sys.platform == 'win32':
         os.kill(tunnel.pid, signal.CTRL_BREAK_EVENT)
     else:
-        os.killpg(os.getpgid(tunnel.pid), signal.SIGTERM)
+        try:
+            os.killpg(os.getpgid(tunnel.pid), signal.SIGTERM)
+        except OSError:
+            print("ERROR: Process did not exist")
+
+    tout, terr = tunnel.communicate()
+    print('Runner STDOUT: {}'.format(tout.decode('utf-8')))
+    print('Runner STDERR: {}'.format(terr.decode('utf-8')))
 
     return (stdout, stderr, ret)
 
@@ -107,4 +114,5 @@ def _node_tunnel(ttype, args, sudo=False):
         cflag = subprocess.CREATE_NEW_PROCESS_GROUP
 
     return subprocess.Popen(shlex.split(cmd), preexec_fn=pfn,
-                            creationflags=cflag)
+                            creationflags=cflag, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)


### PR DESCRIPTION
Previously there was only the output of the command being run against
the tunnel, this made it hard to debug if the tunnel itself failed to
start.