### PR TITLE
cli: Make python3 compatible

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
-# DC/OS Tunnel Subcommand
+# DC/OS CLI Tunnel Subcommand
 
-A DC/OS subcommand that provides SOCKS proxy, HTTP proxy, and VPN access
+A DC/OS CLI subcommand that provides SOCKS proxy, HTTP proxy, and VPN access
 to your DC/OS cluster.
 
 <br>
@@ -29,10 +29,16 @@ Create a virtualenv for the project:
 make env
 ```
 
+Test it with:
+
+```
+./env/bin/dcos-tunnel
+```
+
 ##Binary
 
 ```
-make local-binary
+make binary
 ```
 
 Run it with:
@@ -44,44 +50,14 @@ Run it with:
 
 ##Running Tests
 
-###Setup
-
-Tox, our test runner, tests against both Python 2.7 and Python 3.4 environments.
-
-If you're using OS X, be sure to use the officially distributed Python 3.4 installer since the
-Homebrew version is missing a necessary library.
-
-###Running
-
-Tox will run unit and integration tests in both Python environments using a temporarily created
-virtualenv.
-
-You should ensure `DCOS_CONFIG` is set and that the config file points to the Marathon
-instance you want to use for integration tests.
-
-There are two ways to run tests, you can either use the virtualenv created by `make env`
-above:
+Syntax check:
 
 ```
 make test
 ```
 
-Or, assuming you have tox installed:
+Syntax check + Integration test:
 
 ```
-tox
-```
-
-##Other Useful Commands
-
-List all of the supported test environments:
-
-```
-tox --listenvs
-```
-
-Run a specific set of tests:
-
-```
-tox -e <testenv>
+make test-binary
 ```

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -63,6 +63,7 @@ def _is_privileged():
 def _dangling_proc(procstrlist):
     stdout, _, _ = ssh_output(['ps', 'aux'])
     for line in stdout.splitlines():
+        line = line.decode()
         for pstr in procstrlist:
             if pstr in line:
                 return True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = syntax
+envlist = py34-syntax
 
 [testenv]
 deps =
@@ -7,7 +7,7 @@ deps =
   pytest-cov
 passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
 
-[testenv:syntax]
+[testenv:py34-syntax]
 deps =
   flake8
   isort


### PR DESCRIPTION
Python3 changes several functions to output bytes instead of strings. It
also produces more exceptions to be caught.