### PR TITLE
Optionally log SSH command for `sock` command

### DIFF
--- a/dcos_tunnel/cli.py
+++ b/dcos_tunnel/cli.py
@@ -106,6 +106,7 @@ from dcos_tunnel import constants
 import paramiko
 
 logger = util.get_logger(__name__)
+util.configure_process_from_environ()
 emitter = emitting.FlatEmitter()
 
 # Always use get_pty=True with SSHClient.exec_command()! Otherwise the remote
@@ -401,6 +402,7 @@ def _socks(port, config_file, user, privileged, ssh_port, host, option):
     host = get_host(host)
 
     scom = "ssh -N -D {} {} {}@{}".format(port, ssh_options, user, host)
+    logger.info('SSH command: "%s"', scom)
 
     emitter.publish('SOCKS proxy listening on port {}'.format(port))
     return subprocess_call(shlex.split(scom))


### PR DESCRIPTION
```
$ DCOS_LOG_LEVEL=info ./env/bin/dcos-tunnel tunnel socks
MainThread: 2017-02-25 09:30:57,948 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/dcos/http.py:_request:87 - Sending HTTP ['get'] to ['http://<redacted>/metadata']: {'Accept': 'application/json'}
MainThread: 2017-02-25 09:30:57,958 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:_new_conn:207 - Starting new HTTP connection (1): <redacted>
MainThread: 2017-02-25 09:30:58,573 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/dcos/http.py:_request:117 - Received HTTP response [401]: {'Server': 'openresty/1.9.15.1', 'Date': 'Sat, 25 Feb 2017 17:31:00 GMT', 'Content-Type': 'text/html; charset=UTF-8', 'WWW-Authenticate': 'oauthjwt', 'Content-Length': '363', 'Age': '0', 'Via': '1.1 wsg.sanjose09'}
MainThread: 2017-02-25 09:30:58,574 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/dcos/http.py:_request:87 - Sending HTTP ['get'] to ['http://<redacted>/metadata']: {'Accept': 'application/json'}
MainThread: 2017-02-25 09:30:58,577 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:_new_conn:207 - Starting new HTTP connection (1): <redacted>
MainThread: 2017-02-25 09:30:59,128 /Users/msabramo/dev/git-repos/dcos-tunnel/env/lib/python3.6/site-packages/dcos/http.py:_request:117 - Received HTTP response [200]: {'Server': 'openresty/1.9.15.1', 'Date': 'Sat, 25 Feb 2017 17:31:00 GMT', 'Content-Type': 'application/json', 'Content-Length': '86', 'Age': '0'}
MainThread: 2017-02-25 09:30:59,128 /Users/msabramo/dev/git-repos/dcos-tunnel/dcos_tunnel/cli.py:_socks:405 - SSH command: "ssh -N -D 1080  core@10.10.11.179"
SOCKS proxy listening on port 1080
^C User interrupted command. Exiting...
```

Cc: @adragomir