### PR TITLE
Fixed 1.11 overlay for ipv4 routes

### DIFF
--- a/dcos_tunnel/cli.py
+++ b/dcos_tunnel/cli.py
@@ -652,8 +652,11 @@ class VPNHost(object):
         subnets = []
         data = self.overlay_info()
         logger.debug("overlay info: {}".format(data))
-        for overlay in data['overlays']:
-            subnets.append(overlay['info']['subnet'])
+
+        # Currently we do not have a IPv6 supported
+        for info in data['overlays']:
+            if 'subnet' in info['info']:
+                subnets.append(info['info']['subnet'])
         return subnets
 
     def overlay_info(self):


### PR DESCRIPTION
After introduction of IPv6 overlays in DC/OS 1.11 the overlay struct can have `subnet6` (for IPv6) or `subnet` (for IPv4) or both. When running dcos-tunnel this led to a race condition making it impossible to tunnel into your cluster:

```
Failed to execute script cli
Traceback (most recent call last):
  File "dcos_tunnel/cli.py", line 946, in <module>
  File "dcos_tunnel/cli.py", line 152, in main
  File "site-packages/dcos/cmds.py", line 43, in execute
  File "dcos_tunnel/cli.py", line 831, in _vpn
  File "dcos_tunnel/cli.py", line 603, in gen_hosts
  File "dcos_tunnel/cli.py", line 628, in gen_route_hosts
  File "dcos_tunnel/cli.py", line 656, in maybe_fetch_overlay_routes
KeyError: 'subnet' 
```

